### PR TITLE
fix: Remove getAdRewardSettings dispatch from GameWrapper

### DIFF
--- a/src/components/GameWrapper/GameWrapper.tsx
+++ b/src/components/GameWrapper/GameWrapper.tsx
@@ -11,7 +11,6 @@ import { Outlet } from "react-router-dom";
 import { AppGameMode } from "../../types/AppGameMode";
 import { ESplashTypes } from "../../constants/ESplashTypes";
 import { postLog } from "../../api/logs";
-import { getAdRewardSettings } from "../../store/slices/tasksSlice";
 
 interface Props {
   header: ReactNode;
@@ -58,7 +57,6 @@ const GameWrapper: FC<Props> = ({
     ) => {
       try {
         await dispatch(authorizeUser(initData, avatar, username, mode));
-        dispatch(getAdRewardSettings());
       } catch (error) {
         console.error(error);
       } finally {

--- a/src/store/slices/profileSlice.ts
+++ b/src/store/slices/profileSlice.ts
@@ -21,6 +21,7 @@ import { claimDailyReward, initDailyReward } from "./cyberFarm/activitySlice";
 import { exchange, initSocialShop } from "./cyberFarm/socialShopSlice";
 import {
   claimAdReward,
+  getAdRewardSettings,
   getPromoTaskReward,
   getRewardTaddy,
   verifyGigaHash,
@@ -292,6 +293,8 @@ export const authorizeUser =
 
     try {
       const res = await dispatch(getAccountDetails(avatar, username, mode));
+
+      dispatch(getAdRewardSettings());
 
       if (res.ton_cyber_farm) {
         dispatch(initCyberFarm());


### PR DESCRIPTION
- Eliminated the dispatch of getAdRewardSettings in GameWrapper to streamline user authorization flow.
- Added getAdRewardSettings dispatch in authorizeUser function within profileSlice for better management of ad reward settings.