### PR TITLE
fix: Update adId format in LoyalitySupportProject component

### DIFF
--- a/src/components/Loyality/LoyalitySupportProject/LoyalitySupportProject.tsx
+++ b/src/components/Loyality/LoyalitySupportProject/LoyalitySupportProject.tsx
@@ -261,7 +261,7 @@ const LoyalitySupportProject = () => {
           provider={EadProviders.Adsgram}
           adType={EAdActionTypes.Interstitial}
           index={6}
-          adId="13832"
+          adId="int-13832"
         />
         {Array.isArray(taddyTasks) &&
           taddyTasks?.map((task, index) => (


### PR DESCRIPTION
- Changed adId from "13832" to "int-13832" for consistency with new ad identification standards.
- Ensured compatibility with existing ad management logic.