### PR TITLE
feat: Add removeAdMeditation action and cleanup in useSlotId hook

### DIFF
--- a/src/hooks/useSlotId.ts
+++ b/src/hooks/useSlotId.ts
@@ -1,7 +1,11 @@
 import { useEffect, useState } from "react";
 import { EAdActionTypes } from "../constants/EadActionTypes";
 import { EadProviders } from "../constants/EadProviders";
-import { claimAdReward, getAdMeditation } from "../store/slices/tasksSlice";
+import {
+  claimAdReward,
+  getAdMeditation,
+  removeAdMeditation,
+} from "../store/slices/tasksSlice";
 import { AdRewardValidPairsType } from "../types/tasks/AdRewardValidPairsType";
 import { useAppDispatch, useAppSelector } from "./redux";
 import { useGlobalAdController } from "./useGlobalAdController";
@@ -115,6 +119,10 @@ export const useSoltAd = (slotId: string) => {
         }
       })();
     }
+
+    return () => {
+      dispatch(removeAdMeditation());
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mediation]);
 

--- a/src/store/slices/tasksSlice.ts
+++ b/src/store/slices/tasksSlice.ts
@@ -221,6 +221,9 @@ export const tasksSlice = createSlice({
     getRewardTaddy: (state, { payload }) => {
       state.rewardTaddy = payload;
     },
+    removeAdMeditation: (state) => {
+      state.mediation = null;
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(getPromoTasks.fulfilled, (state, action) => {
@@ -247,6 +250,7 @@ export const tasksSlice = createSlice({
   },
 });
 
-export const { setPromoTaskSubscribed, getRewardTaddy } = tasksSlice.actions;
+export const { setPromoTaskSubscribed, getRewardTaddy, removeAdMeditation } =
+  tasksSlice.actions;
 
 export default tasksSlice.reducer;


### PR DESCRIPTION
- Introduced `removeAdMeditation` action in tasksSlice to reset ad mediation state.
- Updated `useSlotId` hook to dispatch `removeAdMeditation` on cleanup, ensuring proper state management.