### PR TITLE
refactor: Remove debug logging and streamline ad mediation logic

### DIFF
--- a/src/components/OnBoardingPage/OnBoarding/OnBoarding.tsx
+++ b/src/components/OnBoardingPage/OnBoarding/OnBoarding.tsx
@@ -62,8 +62,6 @@ const OnBoarding = () => {
         process.env.REACT_APP_MODE === "dev" ||
         tg.initDataUnsafe.user?.id === 1624247936)
     ) {
-      console.log("tg.initDataUnsafe.user?.id", tg.initDataUnsafe.user?.id);
-
       eruda.init();
     }
     tg.ready();

--- a/src/hooks/useGlobalAdController.ts
+++ b/src/hooks/useGlobalAdController.ts
@@ -32,8 +32,6 @@ export const useGlobalAdController = (
         forceInit ||
         (type === EAdActionTypes.Video && provider === EadProviders.Onclicka)
       ) {
-        console.log("init onclicka");
-
         window
           .initCdTma?.({ id: "6079126" })
           .then((show) => {
@@ -103,8 +101,6 @@ export const useGlobalAdController = (
         }
         case EadProviders.Onclicka: {
           if (type === EAdActionTypes.Video) {
-            console.log({ onclickaAd });
-
             if (!onclickaAd) {
               errClb?.();
               return;

--- a/src/hooks/useSlotId.ts
+++ b/src/hooks/useSlotId.ts
@@ -1,11 +1,7 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { EAdActionTypes } from "../constants/EadActionTypes";
 import { EadProviders } from "../constants/EadProviders";
-import {
-  claimAdReward,
-  getAdMeditation,
-  removeAdMeditation,
-} from "../store/slices/tasksSlice";
+import { claimAdReward, getAdMeditation } from "../store/slices/tasksSlice";
 import { AdRewardValidPairsType } from "../types/tasks/AdRewardValidPairsType";
 import { useAppDispatch, useAppSelector } from "./redux";
 import { useGlobalAdController } from "./useGlobalAdController";
@@ -70,66 +66,48 @@ export const useSoltAd = (slotId: string) => {
     "",
     onSuccess,
     onError,
-    [curSlotDetails],
+    [],
     true
   );
-
-  useEffect(() => {
-    if (mediation) {
-      (async () => {
-        try {
-          const curSlot = mediation[slotId];
-          if (curSlot) {
-            switch (curSlot.status) {
-              case EMediationStatuses.AdAvailable: {
-                await onShowAd();
-                break;
-              }
-              case EMediationStatuses.NoAds: {
-                setTooltipText(noAdText[language]);
-                openTooltip();
-                break;
-              }
-              case EMediationStatuses.Inactive: {
-                setTooltipText(slotInactiveText[language]);
-                openTooltip();
-                break;
-              }
-              case EMediationStatuses.SlotCooldown: {
-                setTooltipText(
-                  adAvailableInSecondsText[language](curSlot.seconds_left)
-                );
-                openTooltip();
-                break;
-              }
-              case EMediationStatuses.AdLimit: {
-                setTooltipText(limitReachedText[language]);
-                openTooltip();
-                break;
-              }
-            }
-          } else {
-            throw new Error("invalid slot id");
-          }
-        } catch (error) {
-          setTooltipText(somethingWentWrong[language]);
-          openTooltip();
-        } finally {
-          setLoading(true);
-        }
-      })();
-    }
-
-    return () => {
-      dispatch(removeAdMeditation());
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mediation]);
 
   const onShow = async () => {
     setLoading(true);
     try {
-      await dispatch(getAdMeditation()).unwrap();
+      const res = await dispatch(getAdMeditation()).unwrap();
+
+      const curSlot = res[slotId];
+      if (curSlot) {
+        switch (curSlot.status) {
+          case EMediationStatuses.AdAvailable: {
+            await onShowAd();
+            break;
+          }
+          case EMediationStatuses.NoAds: {
+            setTooltipText(noAdText[language]);
+            openTooltip();
+            break;
+          }
+          case EMediationStatuses.Inactive: {
+            setTooltipText(slotInactiveText[language]);
+            openTooltip();
+            break;
+          }
+          case EMediationStatuses.SlotCooldown: {
+            setTooltipText(
+              adAvailableInSecondsText[language](curSlot.seconds_left)
+            );
+            openTooltip();
+            break;
+          }
+          case EMediationStatuses.AdLimit: {
+            setTooltipText(limitReachedText[language]);
+            openTooltip();
+            break;
+          }
+        }
+      } else {
+        throw new Error("invalid slot id");
+      }
     } catch (error) {
       setTooltipText(somethingWentWrong[language]);
       openTooltip();

--- a/src/store/slices/tasksSlice.ts
+++ b/src/store/slices/tasksSlice.ts
@@ -221,9 +221,6 @@ export const tasksSlice = createSlice({
     getRewardTaddy: (state, { payload }) => {
       state.rewardTaddy = payload;
     },
-    removeAdMeditation: (state) => {
-      state.mediation = null;
-    },
   },
   extraReducers: (builder) => {
     builder.addCase(getPromoTasks.fulfilled, (state, action) => {
@@ -250,7 +247,6 @@ export const tasksSlice = createSlice({
   },
 });
 
-export const { setPromoTaskSubscribed, getRewardTaddy, removeAdMeditation } =
-  tasksSlice.actions;
+export const { setPromoTaskSubscribed, getRewardTaddy } = tasksSlice.actions;
 
 export default tasksSlice.reducer;


### PR DESCRIPTION
- Removed console log statements from OnBoarding component and useGlobalAdController for cleaner code.
- Simplified the useSlotId hook by eliminating unnecessary useEffect and directly handling ad mediation logic within the onShow function.
- Updated tasksSlice to remove the unused removeAdMeditation action, enhancing overall state management.