### PR TITLE
fix: Update ad reward handling to exclude bonus distribution

### DIFF
--- a/src/store/slices/profileSlice.ts
+++ b/src/store/slices/profileSlice.ts
@@ -399,7 +399,11 @@ export const profileSlice = createSlice({
 
     // tasks
     builder.addCase(claimAdReward.fulfilled, (state, { payload }) => {
-      if (+payload.reward && payload.status === "ok") {
+      if (
+        +payload.reward &&
+        payload.status === "ok" &&
+        !payload.bonus_distribution
+      ) {
         state.stats.cp += +payload.reward;
       }
     });


### PR DESCRIPTION
- Modified the condition for updating CP stats in the claimAdReward case to ensure rewards are only added when there is no bonus distribution present.